### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,54 +5,54 @@
 #######################################
 # Library (KEYWORD3)
 #######################################
-LSM6DS3_Accelerometer	     KEYWORD3
-LSM6DS3_Gyroscope		     KEYWORD3
+LSM6DS3_Accelerometer	KEYWORD3
+LSM6DS3_Gyroscope	KEYWORD3
 
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-OutputDataRate		KEYWORD1
-OperatingMode 		KEYWORD1
-FullScale 	 		KEYWORD1
-Bandwidth			KEYWORD1
+OutputDataRate	KEYWORD1
+OperatingMode	KEYWORD1
+FullScale	KEYWORD1
+Bandwidth	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin					KEYWORD2
-isActive	    		KEYWORD2
-powerOn	   		 		KEYWORD2
-powerOff	    		KEYWORD2
+begin	KEYWORD2
+isActive	KEYWORD2
+powerOn	KEYWORD2
+powerOff	KEYWORD2
 changeOutputDataRate	KEYWORD2
-changeFullScale			KEYWORD2
-changeOperatingMode		KEYWORD2
-changeBandwidth			KEYWORD2
-getConvertedXAxis  		KEYWORD2
-getConvertedYAxis  		KEYWORD2
-getConvertedZAxis		KEYWORD2
-getRawXAxis    			KEYWORD2
-getRawYAxis    			KEYWORD2
-getRawZAxis 			KEYWORD2
-resetToDefault			KEYWORD2
-getStatus				KEYWORD2
+changeFullScale	KEYWORD2
+changeOperatingMode	KEYWORD2
+changeBandwidth	KEYWORD2
+getConvertedXAxis	KEYWORD2
+getConvertedYAxis	KEYWORD2
+getConvertedZAxis	KEYWORD2
+getRawXAxis	KEYWORD2
+getRawYAxis	KEYWORD2
+getRawZAxis	KEYWORD2
+resetToDefault	KEYWORD2
+getStatus	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-XL_HM_Normal			LITERAL1
+XL_HM_Normal	LITERAL1
 XL_HM_High_Performance	LITERAL1
-XL_FS_2G				LITERAL1
-XL_FS_4G				LITERAL1
-XL_FS_8G				LITERAL1
-XL_FS_16G				LITERAL1
-XL_Band_400Hz			LITERAL1
-XL_Band_200Hz			LITERAL1
-XL_Band_100Hz			LITERAL1
-XL_Band_50Hz			LITERAL1
-G_HM_Normal				LITERAL1
+XL_FS_2G	LITERAL1
+XL_FS_4G	LITERAL1
+XL_FS_8G	LITERAL1
+XL_FS_16G	LITERAL1
+XL_Band_400Hz	LITERAL1
+XL_Band_200Hz	LITERAL1
+XL_Band_100Hz	LITERAL1
+XL_Band_50Hz	LITERAL1
+G_HM_Normal	LITERAL1
 G_HM_High_Performance	LITERAL1
-G_FS_245_DPS			LITERAL1
-G_FS_500_DPS			LITERAL1
-G_FS_1000_DPS			LITERAL1
-G_FS_2000_DPS			LITERAL1
+G_FS_245_DPS	LITERAL1
+G_FS_500_DPS	LITERAL1
+G_FS_1000_DPS	LITERAL1
+G_FS_2000_DPS	LITERAL1
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords